### PR TITLE
Updated UI to Fully Support Flutter

### DIFF
--- a/Block/Block.js
+++ b/Block/Block.js
@@ -818,11 +818,11 @@ Block.prototype.checkListUsed=function(list){
 	}
 	return false;
 };
-Block.prototype.hideHBDropDowns=function(){
-	this.passRecursively("hideHBDropDowns");
+Block.prototype.hideDeviceDropDowns=function(){
+	this.passRecursively("hideDeviceDropDowns");
 };
-Block.prototype.showHBDropDowns=function(){
-	this.passRecursively("showHBDropDowns");
+Block.prototype.showDeviceDropDowns=function(){
+	this.passRecursively("showDeviceDropDowns");
 };
 Block.prototype.countHBsInUse=function(){
 	var largest=1;

--- a/Block/Block.js
+++ b/Block/Block.js
@@ -558,38 +558,31 @@ Block.prototype.addHeights=function(){
 /* Returns a copy of this Block, its Slots, subsequent Blocks, and nested Blocks. Uses Recursion.
  * @return {Block} - This Block's copy.
  */
-Block.prototype.duplicate=function(x,y){
-	//Uses the constructor of the Block class but has the methods of this specific Block's subclass.
-	//Allows the Block to be constructed without any Slots initially, so they can be duplicated and added on.
-	var copiedClass=function(type,returnType,x1,y1,category){
-		Block.call(this,type,returnType,x1,y1,category); //Call Block constructor.
-	};
-	copiedClass.prototype = Object.create(this.constructor.prototype); //Copy all functions.
-	copiedClass.prototype.constructor = copiedClass; //Only constructor differs.
+Block.prototype.duplicate = function(x, y) {
+	let blockCopy = new this.constructor(x, y); // Calls constructor of calling object
 
-	var myCopy=new copiedClass(this.type,this.returnType,x,y,this.category); //Make an empty Block of this Block's type.
-	myCopy.blockTypeName=this.blockTypeName;
-	for(var i=0;i<this.parts.length;i++){ //Copy this Block's parts to the new Block.
-		myCopy.addPart(this.parts[i].duplicate(myCopy));
+	// Copy the contents of its Slots.
+	if (this.blockSlot1 != null) { 
+		blockCopy.blockSlot1 = this.blockSlot1.duplicate(blockCopy);
 	}
-	if(this.blockSlot1!=null){ //Copy the contents of its Slots.
-		myCopy.blockSlot1=this.blockSlot1.duplicate(myCopy);
+	if (this.blockSlot2 != null) {
+		blockCopy.blockSlot2 = this.blockSlot2.duplicate(blockCopy);
 	}
-	if(this.blockSlot2!=null){
-		myCopy.blockSlot2=this.blockSlot2.duplicate(myCopy);
+	// Copy subsequent Blocks.
+	if (this.nextBlock != null) {  
+		blockCopy.nextBlock = this.nextBlock.duplicate(0, 0);
+		blockCopy.nextBlock.parent = blockCopy;
 	}
-	if(this.nextBlock!=null){ //Copy subsequent Blocks.
-		myCopy.nextBlock=this.nextBlock.duplicate(0,0);
-		myCopy.nextBlock.parent=myCopy;
+	// Copy variable data if this is a variable Block.
+	if (this.variable != null) {  
+		blockCopy.variable = this.variable;
 	}
-	if(this.variable!=null){ //Copy variable data if this is a variable Block.
-		myCopy.variable=this.variable;
+	// Copy list data if this is a list Block.
+	if (this.list != null) {  
+		blockCopy.list = this.list;
 	}
-	if(this.list!=null){ //Copy list data if this is a list Block.
-		myCopy.list=this.list;
-	}
-	myCopy.bottomOpen=this.bottomOpen; //Set properties not set by constructor.
-	return myCopy; //Return finished Block.
+
+	return blockCopy;  // Return finished Block.
 };
 /* Returns an entirely text-based version of the Block for display in dialogs.
  * May exclude a slot and replace if with "___".

--- a/Block/Block.js
+++ b/Block/Block.js
@@ -575,11 +575,12 @@ Block.prototype.duplicate = function(x, y) {
 	}
 	// Copy variable data if this is a variable Block.
 	if (this.variable != null) {  
-		blockCopy.variable = this.variable;
+		blockCopy.setVar(this.variable);
 	}
 	// Copy list data if this is a list Block.
 	if (this.list != null) {  
 		blockCopy.list = this.list;
+		blockCopy.setList(this.list);
 	}
 
 	return blockCopy;  // Return finished Block.

--- a/BlockContainers/BlockStack.js
+++ b/BlockContainers/BlockStack.js
@@ -480,12 +480,12 @@ BlockStack.prototype.checkVariableUsed=function(variable){
 BlockStack.prototype.checkListUsed=function(list){
 	return this.firstBlock.checkListUsed(list);
 };
-BlockStack.prototype.hideHBDropDowns=function(){
-	this.passRecursively("hideHBDropDowns");
+BlockStack.prototype.hideDeviceDropDowns=function(){
+	this.passRecursively("hideDeviceDropDowns");
 	this.updateDim();
 };
-BlockStack.prototype.showHBDropDowns=function(){
-	this.passRecursively("showHBDropDowns");
+BlockStack.prototype.showDeviceDropDowns=function(){
+	this.passRecursively("showDeviceDropDowns");
 	this.updateDim();
 };
 BlockStack.prototype.countHBsInUse=function(){

--- a/BlockContainers/DisplayStack.js
+++ b/BlockContainers/DisplayStack.js
@@ -101,12 +101,12 @@ DisplayStack.prototype.getSprite=function(){
 DisplayStack.prototype.delete=function(){
 	this.group.remove();
 };
-DisplayStack.prototype.hideHBDropDowns=function(){
-	this.passRecursively("hideHBDropDowns");
+DisplayStack.prototype.hideDeviceDropDowns=function(){
+	this.passRecursively("hideDeviceDropDowns");
 	this.updateDim();
 };
-DisplayStack.prototype.showHBDropDowns=function(){
-	this.passRecursively("showHBDropDowns");
+DisplayStack.prototype.showDeviceDropDowns=function(){
+	this.passRecursively("showDeviceDropDowns");
 	this.updateDim();
 };
 DisplayStack.prototype.passRecursively=function(functionName){

--- a/BlockDefsAndList/BlockDefs_flutter.js
+++ b/BlockDefsAndList/BlockDefs_flutter.js
@@ -127,6 +127,13 @@ B_FlutterKnob.prototype = Object.create(B_FlutterSensorBase.prototype);
 B_FlutterKnob.prototype.constructor = B_FlutterKnob;
 
 
+function B_FlutterSoil(x, y) {
+	B_FlutterSensorBase.call(this, x, y, "soil", "Soil");
+}
+B_FlutterSoil.prototype = Object.create(B_FlutterSensorBase.prototype);
+B_FlutterSoil.prototype.constructor = B_FlutterSoil;
+
+
 function B_FlutterSound(x, y) {
 	B_FlutterSensorBase.call(this, x, y, "sound", "Sound");
 }

--- a/BlockDefsAndList/BlockDefs_flutter.js
+++ b/BlockDefsAndList/BlockDefs_flutter.js
@@ -1,0 +1,174 @@
+/* Output Blocks */
+function B_FlutterServo(x, y) {
+	CommandBlock.call(this, x, y, "flutter");
+	this.addPart(new HBDropSlot(this, FlutterManager));
+	this.addPart(new LabelText(this, "Servo"));
+	this.addPart(new NumSlot(this, 1, true, true)); //Positive integer.
+	this.addPart(new NumSlot(this, 0, true, true)); //Positive integer.
+}
+B_FlutterServo.prototype = Object.create(CommandBlock.prototype);
+B_FlutterServo.prototype.constructor = B_FlutterServo;
+/* Generic flutter single output functions. */
+B_FlutterServo.prototype.startAction = function() {
+	let flutter = FlutterManager.GetDeviceByIndex(this.slots[0].getData().getValue());
+	if (flutter == null) {
+		return false; // Flutter was invalid, exit early
+	}
+	let mem = this.runMem;
+	mem.flutter = flutter;
+	let port = this.slots[1].getData().getValue(); // Positive integer.
+	let value = this.slots[2].getData().getValue(); // [0,180]
+	// TODO: error checking?
+	let shouldSend = CodeManager.checkHBOutputDelay(this.stack);
+	return flutter.setServoOrSave(shouldSend, mem, port, value);
+};
+B_FlutterServo.prototype.updateAction = function() {
+	let shouldSend = CodeManager.checkHBOutputDelay(this.stack);
+	return this.runMem.flutter.setServoOrSave(shouldSend, this.runMem);
+};
+
+function B_FlutterTriLed(x, y) {
+	CommandBlock.call(this, x, y, "flutter");
+	this.addPart(new HBDropSlot(this, FlutterManager));
+	this.addPart(new LabelText(this, "TRI-LED"));
+	this.addPart(new NumSlot(this, 1, true, true)); //Positive integer.
+	this.addPart(new LabelText(this, "R"));
+	this.addPart(new NumSlot(this, 0, true, true)); //Positive integer.
+	this.addPart(new LabelText(this, "G"));
+	this.addPart(new NumSlot(this, 0, true, true)); //Positive integer.
+	this.addPart(new LabelText(this, "B"));
+	this.addPart(new NumSlot(this, 0, true, true)); //Positive integer.
+}
+B_FlutterTriLed.prototype = Object.create(CommandBlock.prototype);
+B_FlutterTriLed.prototype.constructor = B_FlutterTriLed;
+/* Sends a request if the port is an integer from 1 to 4. */
+B_FlutterTriLed.prototype.startAction = function() {
+	let flutter = FlutterManager.GetDeviceByIndex(this.slots[0].getData().getValue());
+	if (flutter == null) {
+		return false; // Flutter was invalid, exit early
+	}
+	let mem = this.runMem;
+	mem.flutter = flutter;
+	let port = this.slots[1].getData().getValueWithC(true, true); // Positive integer.
+	let valueR = this.slots[2].getData().getValueInR(0, 100, true, true); //Positive integer.
+	let valueG = this.slots[3].getData().getValueInR(0, 100, true, true); //Positive integer.
+	let valueB = this.slots[4].getData().getValueInR(0, 100, true, true); //Positive integer.
+	let shouldSend = CodeManager.checkHBOutputDelay(this.stack);
+	return flutter.setTriLEDOrSave(shouldSend, mem, port, valueR, valueG, valueB);
+};
+/* Waits for the request to finish. */
+B_FlutterTriLed.prototype.updateAction = function() {
+	let shouldSend = CodeManager.checkHBOutputDelay(this.stack);
+	return this.runMem.flutter.setTriLEDOrSave(shouldSend, this.runMem);
+};
+
+/* Input Blocks */
+function B_FlutterSensorBase(x, y, sensorType, displayName) {
+	ReporterBlock.call(this, x, y, "flutter");
+	this.sensorType = sensorType;
+	this.displayName = displayName;
+	this.addPart(new HBDropSlot(this, FlutterManager));
+	this.addPart(new LabelText(this, displayName));
+	this.addPart(new NumSlot(this, 1, true, true)); //Positive integer.
+}
+B_FlutterSensorBase.prototype = Object.create(ReporterBlock.prototype);
+B_FlutterSensorBase.constructor = B_FlutterSensorBase;
+B_FlutterSensorBase.prototype.startAction = function() {
+	let flutter = FlutterManager.GetDeviceByIndex(this.slots[0].getData().getValue());
+	if (flutter == null) {
+		this.resultData = new StringData("Flutter not connected");
+		return false; // Flutter was invalid, exit early
+	}
+	let mem = this.runMem;
+	mem.flutter = flutter;
+	let port = this.slots[1].getData().getValue();
+	if (port != null && port > 0 && port < 4) {
+		return flutter.readSensor(mem, this.sensorType, port);
+	} else {
+		this.resultData = new StringData("Invalid port number");
+		return false; // Invalid port, exit early
+	}
+}
+B_FlutterSensorBase.prototype.updateAction = function() {
+	if (this.runMem.flutter == null) {
+		return false; // Exited early
+	}
+	if (this.runMem.flutter.readSensor(this.runMem) == false) {
+		this.resultData = new NumData(parseInt(this.runMem.requestStatus.result));
+		return false; // Done
+	}
+	return true; // Still running	
+}
+
+function B_FlutterLight(x, y) {
+	B_FlutterSensorBase.call(this, x, y, "light", "Light");
+}
+B_FlutterLight.prototype = Object.create(B_FlutterSensorBase.prototype);
+B_FlutterLight.prototype.constructor = B_FlutterLight;
+
+function B_FlutterTempC(x, y) {
+	B_FlutterSensorBase.call(this, x, y, "temperature", "Temperature C");
+}
+B_FlutterTempC.prototype = Object.create(B_FlutterSensorBase.prototype);
+B_FlutterTempC.prototype.constructor = B_FlutterTempC;
+
+
+function B_FlutterDistCM(x, y) {
+	B_FlutterSensorBase.call(this, x, y, "distance", "Distance CM");
+}
+B_FlutterDistCM.prototype = Object.create(B_FlutterSensorBase.prototype);
+B_FlutterDistCM.prototype.constructor = B_FlutterDistCM;
+
+
+function B_FlutterKnob(x, y) {
+	B_FlutterSensorBase.call(this, x, y, "sensor", "Knob");
+}
+B_FlutterKnob.prototype = Object.create(B_FlutterSensorBase.prototype);
+B_FlutterKnob.prototype.constructor = B_FlutterKnob;
+
+
+function B_FlutterSound(x, y) {
+	B_FlutterSensorBase.call(this, x, y, "sound", "Sound");
+}
+B_FlutterSound.prototype = Object.create(B_FlutterSensorBase.prototype);
+B_FlutterSound.prototype.constructor = B_FlutterSound;
+
+
+function B_FlutterTempF(x, y) {
+	B_FlutterSensorBase.call(this, x, y, "temperature", "Temperature F");
+}
+B_FlutterTempF.prototype = Object.create(B_FlutterSensorBase.prototype);
+B_FlutterTempF.prototype.constructor = B_FlutterTempF;
+/* Waits for the request to finish then converts C to F. */
+B_FlutterTempF.prototype.updateAction = function() {
+	if (!B_FlutterSensorBase.prototype.updateAction.call(this)) {
+		if (this.resultData.isValid) {
+			let tempInC = this.runMem.requestStatus.result;
+			let tempInF = Math.round(tempInC * 1.8 + 32);
+			this.resultData = new NumData(tempInF); //Rounded to Integer
+		}
+		return false; //Done running
+	} else {
+		return true; //Still running
+	}
+};
+
+function B_FlutterDistInch(x, y) {
+	B_FlutterSensorBase.call(this, x, y, "distance", "Distance Inch");
+}
+B_FlutterDistInch.prototype = Object.create(B_FlutterSensorBase.prototype);
+B_FlutterDistInch.prototype.constructor = B_FlutterDistInch;
+/* Waits for the request to finish then converts cm to in. */
+B_FlutterDistInch.prototype.updateAction = function() {
+	if (!B_FlutterSensorBase.prototype.updateAction.call(this)) {
+		if (this.resultData.isValid) {
+			let distInCM = this.runMem.requestStatus.result;
+			// Rounded to 1 decimal place. "*1" converts to num.
+			let distInInches = (distInCM / 2.54).toFixed(1) * 1;
+			this.resultData = new NumData(distInInches);
+		}
+		return false; //Done running
+	} else {
+		return true; //Still running
+	}
+};

--- a/BlockDefsAndList/BlockDefs_flutter.js
+++ b/BlockDefsAndList/BlockDefs_flutter.js
@@ -29,7 +29,7 @@ B_FlutterServo.prototype.updateAction = function() {
 
 function B_FlutterTriLed(x, y) {
 	CommandBlock.call(this, x, y, "flutter");
-	this.addPart(new DeviceDropSlot(this, FlutterManager));
+	this.addPart(new DeviceDropSlot(this, FlutterManager, true));
 	this.addPart(new LabelText(this, "TRI-LED"));
 	this.addPart(new NumSlot(this, 1, true, true)); //Positive integer.
 	this.addPart(new LabelText(this, "R"));

--- a/BlockDefsAndList/BlockDefs_flutter.js
+++ b/BlockDefsAndList/BlockDefs_flutter.js
@@ -1,7 +1,7 @@
 /* Output Blocks */
 function B_FlutterServo(x, y) {
 	CommandBlock.call(this, x, y, "flutter");
-	this.addPart(new HBDropSlot(this, FlutterManager));
+	this.addPart(new DeviceDropSlot(this, FlutterManager));
 	this.addPart(new LabelText(this, "Servo"));
 	this.addPart(new NumSlot(this, 1, true, true)); //Positive integer.
 	this.addPart(new NumSlot(this, 0, true, true)); //Positive integer.
@@ -29,7 +29,7 @@ B_FlutterServo.prototype.updateAction = function() {
 
 function B_FlutterTriLed(x, y) {
 	CommandBlock.call(this, x, y, "flutter");
-	this.addPart(new HBDropSlot(this, FlutterManager));
+	this.addPart(new DeviceDropSlot(this, FlutterManager));
 	this.addPart(new LabelText(this, "TRI-LED"));
 	this.addPart(new NumSlot(this, 1, true, true)); //Positive integer.
 	this.addPart(new LabelText(this, "R"));
@@ -67,7 +67,7 @@ function B_FlutterSensorBase(x, y, sensorType, displayName) {
 	ReporterBlock.call(this, x, y, "flutter");
 	this.sensorType = sensorType;
 	this.displayName = displayName;
-	this.addPart(new HBDropSlot(this, FlutterManager));
+	this.addPart(new DeviceDropSlot(this, FlutterManager));
 	this.addPart(new LabelText(this, displayName));
 	this.addPart(new NumSlot(this, 1, true, true)); //Positive integer.
 }

--- a/BlockDefsAndList/BlockDefs_hummingbird.js
+++ b/BlockDefsAndList/BlockDefs_hummingbird.js
@@ -5,7 +5,7 @@
 
 function B_HBServo(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this));
+	this.addPart(new HBDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Servo"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new NumSlot(this,0,true,true)); //Positive integer.
@@ -24,7 +24,7 @@ B_HBServo.prototype.updateAction=function(){
 
 function B_HBLight(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this));
+	this.addPart(new HBDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Light"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -42,7 +42,7 @@ B_HBLight.prototype.updateAction=function(){
 
 function B_HBMotor(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this));
+	this.addPart(new HBDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Motor"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new NumSlot(this,0, false, true)); //Integer
@@ -59,7 +59,7 @@ B_HBMotor.prototype.updateAction=function(){
 
 function B_HBVibration(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this));
+	this.addPart(new HBDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Vibration"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new NumSlot(this,0,true, true)); //Positive integer.
@@ -78,7 +78,7 @@ B_HBVibration.prototype.updateAction=function(){
 
 function B_HBLed(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this));
+	this.addPart(new HBDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"LED"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new NumSlot(this,0,true, true)); //Positive integer.
@@ -97,7 +97,7 @@ B_HBLed.prototype.updateAction=function(){
 
 function B_HBTempC(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this,true));
+	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"Temperature C"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -115,7 +115,7 @@ B_HBTempC.prototype.updateAction=function(){
 
 function B_HBDistCM(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this,true));
+	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"Distance CM"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -133,7 +133,7 @@ B_HBDistCM.prototype.updateAction=function(){
 
 function B_HBKnob(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this));
+	this.addPart(new HBDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Knob"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -151,7 +151,7 @@ B_HBKnob.prototype.updateAction=function(){
 
 function B_HBSound(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this,true));
+	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"Sound"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -171,7 +171,7 @@ B_HBSound.prototype.updateAction=function(){
 
 function B_HBTriLed(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this,true));
+	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"TRI-LED"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new LabelText(this,"R"));
@@ -224,7 +224,7 @@ B_HBTriLed.prototype.updateAction=function(){
 
 function B_HBTempF(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this,true));
+	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"Temperature F"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -251,7 +251,7 @@ B_HBTempF.prototype.updateAction=function(){
 
 function B_HBDistInch(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-    this.addPart(new HBDropSlot(this,true));
+    this.addPart(new HBDropSlot(this, HummingbirdManager, true));
     this.addPart(new LabelText(this,"HB Distance Inch"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }

--- a/BlockDefsAndList/BlockDefs_hummingbird.js
+++ b/BlockDefsAndList/BlockDefs_hummingbird.js
@@ -5,7 +5,7 @@
 
 function B_HBServo(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Servo"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new NumSlot(this,0,true,true)); //Positive integer.
@@ -24,7 +24,7 @@ B_HBServo.prototype.updateAction=function(){
 
 function B_HBLight(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Light"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -42,7 +42,7 @@ B_HBLight.prototype.updateAction=function(){
 
 function B_HBMotor(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Motor"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new NumSlot(this,0, false, true)); //Integer
@@ -59,7 +59,7 @@ B_HBMotor.prototype.updateAction=function(){
 
 function B_HBVibration(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Vibration"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new NumSlot(this,0,true, true)); //Positive integer.
@@ -78,7 +78,7 @@ B_HBVibration.prototype.updateAction=function(){
 
 function B_HBLed(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"LED"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new NumSlot(this,0,true, true)); //Positive integer.
@@ -97,7 +97,7 @@ B_HBLed.prototype.updateAction=function(){
 
 function B_HBTempC(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"Temperature C"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -115,7 +115,7 @@ B_HBTempC.prototype.updateAction=function(){
 
 function B_HBDistCM(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"Distance CM"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -133,7 +133,7 @@ B_HBDistCM.prototype.updateAction=function(){
 
 function B_HBKnob(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager));
 	this.addPart(new LabelText(this,"Knob"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -151,7 +151,7 @@ B_HBKnob.prototype.updateAction=function(){
 
 function B_HBSound(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"Sound"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -171,7 +171,7 @@ B_HBSound.prototype.updateAction=function(){
 
 function B_HBTriLed(x,y){
 	CommandBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"TRI-LED"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 	this.addPart(new LabelText(this,"R"));
@@ -224,7 +224,7 @@ B_HBTriLed.prototype.updateAction=function(){
 
 function B_HBTempF(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-	this.addPart(new HBDropSlot(this, HummingbirdManager, true));
+	this.addPart(new DeviceDropSlot(this, HummingbirdManager, true));
 	this.addPart(new LabelText(this,"Temperature F"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }
@@ -251,7 +251,7 @@ B_HBTempF.prototype.updateAction=function(){
 
 function B_HBDistInch(x,y){
 	ReporterBlock.call(this,x,y,"hummingbird");
-    this.addPart(new HBDropSlot(this, HummingbirdManager, true));
+    this.addPart(new DeviceDropSlot(this, HummingbirdManager, true));
     this.addPart(new LabelText(this,"HB Distance Inch"));
 	this.addPart(new NumSlot(this,1,true,true)); //Positive integer.
 }

--- a/BlockDefsAndList/BlockDefs_variables.js
+++ b/BlockDefsAndList/BlockDefs_variables.js
@@ -2,8 +2,10 @@
 
 function B_Variable(x,y,variable){
 	ReporterBlock.call(this,x,y,"variables",Block.returnTypes.string);
-	this.variable=variable;
-	this.addPart(new LabelText(this,this.variable.getName()));
+	if (variable != null) {
+		this.variable=variable;
+		this.addPart(new LabelText(this,this.variable.getName()));
+	}
 }
 B_Variable.prototype = Object.create(ReporterBlock.prototype);
 B_Variable.prototype.constructor = B_Variable;
@@ -17,6 +19,12 @@ B_Variable.prototype.createXml=function(xmlDoc){
 	XmlWriter.setAttribute(block,"variable",this.variable.getName());
 	return block;
 };
+B_Variable.prototype.setVar=function(variable){
+	if (variable != null) {
+		this.variable=variable;
+		this.addPart(new LabelText(this,this.variable.getName()));
+	}
+}
 B_Variable.prototype.renameVar=function(){
 	this.variable.rename();	
 };
@@ -109,8 +117,10 @@ B_ChangeBy.prototype.startAction=function(){
 //Done
 function B_List(x,y,list){
 	ReporterBlock.call(this,x,y,"lists",Block.returnTypes.string);
-	this.list=list;
-	this.addPart(new LabelText(this,this.list.getName()));
+	if (list != null) {
+		this.list=list;
+		this.addPart(new LabelText(this,this.list.getName()));
+	}
 }
 B_List.prototype = Object.create(ReporterBlock.prototype);
 B_List.prototype.constructor = B_List;
@@ -124,6 +134,12 @@ B_List.prototype.createXml=function(xmlDoc){
 	XmlWriter.setAttribute(block,"list",this.list.getName());
 	return block;
 };
+B_Variable.prototype.setList=function(list){
+	if (list != null) {
+		this.list=list;
+		this.addPart(new LabelText(this,this.list.getName()));
+	}
+}
 B_List.importXml=function(blockNode){
 	var listName=XmlWriter.getAttribute(blockNode,"list");
 	var list=CodeManager.findList(listName);

--- a/BlockDefsAndList/BlockList.js
+++ b/BlockDefsAndList/BlockList.js
@@ -7,6 +7,7 @@ function BlockList(){
 	//List only includes categories that will appear in the BlockPalette. "Lists" category is excluded.
 	var cat=BlockList.categories;
 	cat.push("Hummingbird"); //Capitalized in the way they are displayed on screen.
+	cat.push("Flutter");
 	cat.push("Operators");
 	cat.push("Sound");
 	cat.push("Tablet");
@@ -61,6 +62,19 @@ BlockList.populateCat_hummingbird=function(category){
 	category.addBlockByName("B_HBDistInch");
 	category.addBlockByName("B_HBKnob");
 	category.addBlockByName("B_HBSound");
+	category.trimBottom();
+};
+BlockList.populateCat_flutter=function(category){
+	category.addBlockByName("B_FlutterServo");
+	category.addBlockByName("B_FlutterTriLed");
+	category.addSpace();
+	category.addBlockByName("B_FlutterLight");
+	category.addBlockByName("B_FlutterTempC");
+	category.addBlockByName("B_FlutterTempF");
+	category.addBlockByName("B_FlutterDistCM");
+	category.addBlockByName("B_FlutterDistInch");
+	category.addBlockByName("B_FlutterKnob");
+	category.addBlockByName("B_FlutterSound");
 	category.trimBottom();
 };
 BlockList.populateCat_motion=function(category){

--- a/BlockDefsAndList/BlockList.js
+++ b/BlockDefsAndList/BlockList.js
@@ -6,8 +6,8 @@ function BlockList(){
 	BlockList.categories=new Array();
 	//List only includes categories that will appear in the BlockPalette. "Lists" category is excluded.
 	var cat=BlockList.categories;
-	cat.push("Hummingbird"); //Capitalized in the way they are displayed on screen.
-	cat.push("Flutter");
+	// Catetory names should be capitalized in the way they should be displayed on screen.
+	cat.push("Robots"); 
 	cat.push("Operators");
 	cat.push("Sound");
 	cat.push("Tablet");
@@ -47,6 +47,24 @@ BlockList.catCount=function(){
  * Blocks are added with category.addBlockByName(blockNameAsString) and spaces between groups with category.addSpace().
  * category.trimBottom() is used to remove any extra space at the bottom of the category.
  */
+BlockList.populateCat_robots = function(category) {
+	if (HummingbirdManager.GetDeviceCount() > 0 || FlutterManager.GetDeviceCount() > 0) {
+		if (FlutterManager.GetDeviceCount() > 0) {
+			category.addLabel("Flutter");
+			category.addSpace();
+			BlockList.populateCat_flutter(category);
+			category.addSpace();
+		}
+		if (HummingbirdManager.GetDeviceCount() > 0) {
+			category.addLabel("Hummingbird");
+			category.addSpace();
+			BlockList.populateCat_hummingbird(category);
+			category.addSpace();
+		}
+	} else {
+		category.addLabel("Connect a robot first...");
+	}
+}
 BlockList.populateCat_hummingbird=function(category){
 	category.addBlockByName("B_HBServo");
 	category.addBlockByName("B_HBMotor");

--- a/BlockDefsAndList/BlockList.js
+++ b/BlockDefsAndList/BlockList.js
@@ -93,6 +93,7 @@ BlockList.populateCat_flutter=function(category){
 	category.addBlockByName("B_FlutterDistInch");
 	category.addBlockByName("B_FlutterKnob");
 	category.addBlockByName("B_FlutterSound");
+	category.addBlockByName("B_FlutterSoil");
 	category.trimBottom();
 };
 BlockList.populateCat_motion=function(category){

--- a/BlockParts/Slot/BlockSlot.js
+++ b/BlockParts/Slot/BlockSlot.js
@@ -226,11 +226,11 @@ BlockSlot.prototype.checkListUsed=function(list){
 	}
 	return false;
 };
-BlockSlot.prototype.hideHBDropDowns=function(){
-	this.passRecursively("hideHBDropDowns");
+BlockSlot.prototype.hideDeviceDropDowns=function(){
+	this.passRecursively("hideDeviceDropDowns");
 };
-BlockSlot.prototype.showHBDropDowns=function(){
-	this.passRecursively("showHBDropDowns");
+BlockSlot.prototype.showDeviceDropDowns=function(){
+	this.passRecursively("showDeviceDropDowns");
 };
 BlockSlot.prototype.countHBsInUse=function(){
 	if(this.hasChild){

--- a/BlockParts/Slot/DeviceDropSlot.js
+++ b/BlockParts/Slot/DeviceDropSlot.js
@@ -84,7 +84,6 @@ DeviceDropSlot.prototype.countHBsInUse = function() {
 	}
 };
 
-// TODO: Backwards compatibility? (Used to be called HBDropSlot)
 DeviceDropSlot.prototype.importXml = function(slotNode) {
 	DropSlot.prototype.importXml.call(this, slotNode);
 	this.enteredData = new SelectionData(parseInt(this.enteredData.getValue()));

--- a/BlockParts/Slot/DeviceDropSlot.js
+++ b/BlockParts/Slot/DeviceDropSlot.js
@@ -1,4 +1,4 @@
-function HBDropSlot(parent, DeviceManager, shortText) {
+function DeviceDropSlot(parent, DeviceManager, shortText) {
 	if (shortText == null) {
 		shortText = false;
 	}
@@ -17,9 +17,9 @@ function HBDropSlot(parent, DeviceManager, shortText) {
 	}
 }
 
-HBDropSlot.prototype = Object.create(DropSlot.prototype);
-HBDropSlot.prototype.constructor = HBDropSlot;
-HBDropSlot.prototype.populateList = function() {
+DeviceDropSlot.prototype = Object.create(DropSlot.prototype);
+DeviceDropSlot.prototype.constructor = DeviceDropSlot;
+DeviceDropSlot.prototype.populateList = function() {
 	this.clearOptions();
 	var deviceCount = this.DeviceManager.GetDeviceCount();
 	for (var i = 0; i < deviceCount; i++) {
@@ -27,14 +27,14 @@ HBDropSlot.prototype.populateList = function() {
 	}
 };
 
-HBDropSlot.prototype.duplicate = function(parentCopy) {
-	var myCopy = new HBDropSlot(parentCopy, this.DeviceManager, this.shortText);
+DeviceDropSlot.prototype.duplicate = function(parentCopy) {
+	var myCopy = new DeviceDropSlot(parentCopy, this.DeviceManager, this.shortText);
 	myCopy.enteredData = this.enteredData;
 	myCopy.changeText(this.text);
 	return myCopy;
 };
 
-HBDropSlot.prototype.switchToLabel = function() {
+DeviceDropSlot.prototype.switchToLabel = function() {
 	if (!this.labelMode) {
 		this.labelMode = true;
 		this.setSelectionData(this.prefixText + 1, new SelectionData(0));
@@ -43,7 +43,7 @@ HBDropSlot.prototype.switchToLabel = function() {
 	}
 };
 
-HBDropSlot.prototype.switchToSlot = function() {
+DeviceDropSlot.prototype.switchToSlot = function() {
 	if (this.labelMode) {
 		this.labelMode = false;
 		this.labelText.hide();
@@ -51,7 +51,7 @@ HBDropSlot.prototype.switchToSlot = function() {
 	}
 };
 
-HBDropSlot.prototype.updateAlign = function(x, y) {
+DeviceDropSlot.prototype.updateAlign = function(x, y) {
 	if (this.labelMode) {
 		return LabelText.prototype.updateAlign.call(this.labelText, x, y);
 	} else {
@@ -59,7 +59,7 @@ HBDropSlot.prototype.updateAlign = function(x, y) {
 	}
 };
 
-HBDropSlot.prototype.updateDim = function() {
+DeviceDropSlot.prototype.updateDim = function() {
 	if (this.labelMode) {
 		LabelText.prototype.updateDim.call(this.labelText);
 		this.width = this.labelText.width;
@@ -68,15 +68,15 @@ HBDropSlot.prototype.updateDim = function() {
 	}
 };
 
-HBDropSlot.prototype.hideHBDropDowns = function() {
+DeviceDropSlot.prototype.hideDeviceDropDowns = function() {
 	this.switchToLabel();
 };
 
-HBDropSlot.prototype.showHBDropDowns = function() {
+DeviceDropSlot.prototype.showDeviceDropDowns = function() {
 	this.switchToSlot();
 };
 
-HBDropSlot.prototype.countHBsInUse = function() {
+DeviceDropSlot.prototype.countHBsInUse = function() {
 	if (this.getData() != null) {
 		return this.getData().getValue() + 1;
 	} else {
@@ -84,7 +84,8 @@ HBDropSlot.prototype.countHBsInUse = function() {
 	}
 };
 
-HBDropSlot.prototype.importXml = function(slotNode) {
+// TODO: Backwards compatibility? (Used to be called HBDropSlot)
+DeviceDropSlot.prototype.importXml = function(slotNode) {
 	DropSlot.prototype.importXml.call(this, slotNode);
 	this.enteredData = new SelectionData(parseInt(this.enteredData.getValue()));
 	if (this.enteredData.getValue() < 0) {

--- a/BlockParts/Slot/HBDropSlot.js
+++ b/BlockParts/Slot/HBDropSlot.js
@@ -1,90 +1,93 @@
-function HBDropSlot(parent,shortText){
-	if(shortText==null){
-		shortText=false;
+function HBDropSlot(parent, DeviceManager, shortText) {
+	if (shortText == null) {
+		shortText = false;
 	}
-	this.shortText=shortText;
-	DropSlot.call(this,parent,Slot.snapTypes.none);
-	if(this.shortText){
-		this.hBPrefix="HB ";
-	}
-	else{
-		this.hBPrefix="Hummingbird ";
-	}
-	this.labelText=new LabelText(this.parent,this.hBPrefix.trim());
-	this.labelMode=false;
-	this.setSelectionData(this.hBPrefix+1,new SelectionData(0));
-	if(HummingbirdManager.getSelectableHBCount()<=1) {
+	this.shortText = shortText;
+	DropSlot.call(this, parent, Slot.snapTypes.none);
+	this.prefixText = DeviceManager.GetDeviceName(shortText) + " ";
+	this.DeviceManager = DeviceManager;
+	this.labelText = new LabelText(this.parent, this.prefixText.trim());
+	this.labelMode = false;
+	this.setSelectionData(this.prefixText + 1, new SelectionData(0));
+
+	if (DeviceManager.GetDeviceCount() <= 1) {
 		this.switchToLabel();
-	}
-	else{
+	} else {
 		this.labelText.hide();
 	}
 }
+
 HBDropSlot.prototype = Object.create(DropSlot.prototype);
 HBDropSlot.prototype.constructor = HBDropSlot;
-HBDropSlot.prototype.populateList=function(){
+HBDropSlot.prototype.populateList = function() {
 	this.clearOptions();
-	var hBCount=HummingbirdManager.getSelectableHBCount();
-	for(var i=0;i<hBCount;i++){
-		this.addOption(this.hBPrefix+(i+1),new SelectionData(i)); //We'll store a 0-indexed value but display it +1.
+	var deviceCount = this.DeviceManager.GetDeviceCount();
+	for (var i = 0; i < deviceCount; i++) {
+		this.addOption(this.prefixText + (i + 1), new SelectionData(i)); //We'll store a 0-indexed value but display it +1.
 	}
 };
-HBDropSlot.prototype.duplicate=function(parentCopy){
-	var myCopy=new HBDropSlot(parentCopy,this.shortText);
-	myCopy.enteredData=this.enteredData;
+
+HBDropSlot.prototype.duplicate = function(parentCopy) {
+	var myCopy = new HBDropSlot(parentCopy, this.DeviceManager, this.shortText);
+	myCopy.enteredData = this.enteredData;
 	myCopy.changeText(this.text);
 	return myCopy;
 };
-HBDropSlot.prototype.switchToLabel=function(){
-	if(!this.labelMode){
-		this.labelMode=true;
-		this.setSelectionData(this.hBPrefix+1,new SelectionData(0));
+
+HBDropSlot.prototype.switchToLabel = function() {
+	if (!this.labelMode) {
+		this.labelMode = true;
+		this.setSelectionData(this.prefixText + 1, new SelectionData(0));
 		this.labelText.show();
 		this.hideSlot();
 	}
 };
-HBDropSlot.prototype.switchToSlot=function(){
-	if(this.labelMode){
-		this.labelMode=false;
+
+HBDropSlot.prototype.switchToSlot = function() {
+	if (this.labelMode) {
+		this.labelMode = false;
 		this.labelText.hide();
 		this.showSlot();
 	}
 };
-HBDropSlot.prototype.updateAlign=function(x,y){
-	if(this.labelMode){
-		return LabelText.prototype.updateAlign.call(this.labelText,x,y);
-	}
-	else{
-		return DropSlot.prototype.updateAlign.call(this,x,y);
+
+HBDropSlot.prototype.updateAlign = function(x, y) {
+	if (this.labelMode) {
+		return LabelText.prototype.updateAlign.call(this.labelText, x, y);
+	} else {
+		return DropSlot.prototype.updateAlign.call(this, x, y);
 	}
 };
-HBDropSlot.prototype.updateDim=function(){
-	if(this.labelMode){
+
+HBDropSlot.prototype.updateDim = function() {
+	if (this.labelMode) {
 		LabelText.prototype.updateDim.call(this.labelText);
-		this.width=this.labelText.width;
-	}
-	else{
+		this.width = this.labelText.width;
+	} else {
 		DropSlot.prototype.updateDim.call(this);
 	}
 };
-HBDropSlot.prototype.hideHBDropDowns=function(){
+
+HBDropSlot.prototype.hideHBDropDowns = function() {
 	this.switchToLabel();
 };
-HBDropSlot.prototype.showHBDropDowns=function(){
+
+HBDropSlot.prototype.showHBDropDowns = function() {
 	this.switchToSlot();
 };
-HBDropSlot.prototype.countHBsInUse=function(){
+
+HBDropSlot.prototype.countHBsInUse = function() {
 	if (this.getData() != null) {
 		return this.getData().getValue() + 1;
-	}
-	else {
+	} else {
 		return 1;
 	}
 };
-HBDropSlot.prototype.importXml=function(slotNode) {
-	DropSlot.prototype.importXml.call(this,slotNode);
-	this.enteredData=new SelectionData(parseInt(this.enteredData.getValue()));
-	if(this.enteredData.getValue()<0){
-		this.setSelectionData(this.hBPrefix+1,new SelectionData(0));
+
+HBDropSlot.prototype.importXml = function(slotNode) {
+	DropSlot.prototype.importXml.call(this, slotNode);
+	this.enteredData = new SelectionData(parseInt(this.enteredData.getValue()));
+	if (this.enteredData.getValue() < 0) {
+		this.setSelectionData(this.prefixText + 1, new SelectionData(0));
 	}
 };

--- a/BlockParts/Slot/Slot.js
+++ b/BlockParts/Slot/Slot.js
@@ -315,11 +315,11 @@ Slot.prototype.renameList=function(list){
 Slot.prototype.deleteList=function(list){
 	this.passRecursively("deleteList",list);
 };
-Slot.prototype.hideHBDropDowns=function(){
-	this.passRecursively("hideHBDropDowns");
+Slot.prototype.hideDeviceDropDowns=function(){
+	this.passRecursively("hideDeviceDropDowns");
 };
-Slot.prototype.showHBDropDowns=function(){
-	this.passRecursively("showHBDropDowns");
+Slot.prototype.showDeviceDropDowns=function(){
+	this.passRecursively("showDeviceDropDowns");
 };
 Slot.prototype.countHBsInUse=function(){
 	if(this.hasChild){

--- a/CodeManager.js
+++ b/CodeManager.js
@@ -428,13 +428,13 @@ CodeManager.updateAvailableMessages=function(){
 CodeManager.eventBroadcast=function(message){
 	TabManager.eventBroadcast(message);
 };
-CodeManager.hideHBDropDowns=function(){
-	TabManager.hideHBDropDowns();
-	BlockPalette.hideHBDropDowns();
+CodeManager.hideDeviceDropDowns=function(){
+	TabManager.hideDeviceDropDowns();
+	BlockPalette.hideDeviceDropDowns();
 };
-CodeManager.showHBDropDowns=function(){
-	TabManager.showHBDropDowns();
-	BlockPalette.showHBDropDowns();
+CodeManager.showDeviceDropDowns=function(){
+	TabManager.showDeviceDropDowns();
+	BlockPalette.showDeviceDropDowns();
 };
 CodeManager.countHBsInUse=function(){
 	return TabManager.countHBsInUse();

--- a/ColorsAndGraphics/Colors.js
+++ b/ColorsAndGraphics/Colors.js
@@ -13,6 +13,7 @@ Colors.setCommon=function(){
 };
 Colors.setCategory=function(){
 	Colors.hummingbird="#FF9600";
+	Colors.flutter="#FF9600";
 	Colors.motion="#0000FF";
 	Colors.looks="#8800FF";
 	Colors.sound="#EE00FF"; //FF0088

--- a/ColorsAndGraphics/Colors.js
+++ b/ColorsAndGraphics/Colors.js
@@ -12,18 +12,21 @@ Colors.setCommon=function(){
 	Colors.black="#000";
 };
 Colors.setCategory=function(){
-	Colors.hummingbird="#FF9600";
-	Colors.flutter="#FF9600";
-	Colors.motion="#0000FF";
-	Colors.looks="#8800FF";
-	Colors.sound="#EE00FF"; //FF0088
-	Colors.pen="#00CC99";
-	Colors.tablet="#019EFF"; //7F7F7F
-	Colors.control="#FFCC00";
-	Colors.sensing="#019EFF";
-	Colors.operators="#44FF00";
-	Colors.variables="#FF5B00";
-	Colors.lists="#FF0000";
+	Colors.categoryColors = {
+		"robots": "#FF9600",
+		"hummingbird": "#FF9600",
+		"flutter": "#FF9600",
+		"motion": "#0000FF",
+		"looks": "#8800FF",
+		"sound": "#EE00FF", //FF0088
+		"pen": "#00CC99",
+		"tablet": "#019EFF", //7F7F7F
+		"control": "#FFCC00",
+		"sensing": "#019EFF",
+		"operators": "#44FF00",
+		"variables": "#FF5B00",
+		"lists": "#FF0000",
+	};
 };
 Colors.setMultipliers=function(){
 	Colors.gradStart=1;
@@ -36,13 +39,10 @@ Colors.createGradients=function(){
 	Colors.createGradientSet("gradient_dark_",Colors.gradDarkStart,Colors.gradDarkEnd);
 };
 Colors.createGradientSet=function(name,multStart,multEnd){
-	var categoryCount=BlockList.catCount();
-	for(var i=0; i<categoryCount;i++){
-		var catId=BlockList.getCatId(i);
-		var color=Colors[catId];
-		Colors.createGradientFromColorAndMults(name,catId,color,multStart,multEnd);
-	}
-	Colors.createGradientFromColorAndMults(name,"lists",Colors.lists,multStart,multEnd);
+	Object.keys(Colors.categoryColors).map(function(category) {
+		let color = Colors.categoryColors[category];
+		Colors.createGradientFromColorAndMults(name,category,color,multStart,multEnd);
+	});
 };
 Colors.createGradientFromColorAndMults=function(name,catId,color,multStart,multEnd){
 	var darken=Colors.darkenColor;
@@ -61,7 +61,7 @@ Colors.darkenColor=function(color,amt){
 	return "#"+result;
 };
 Colors.getColor=function(category){
-	return Colors[category];
+	return Colors.categoryColors[category];
 };
 Colors.getGradient=function(category){
 	return "url(#gradient_"+category+")";

--- a/Flutter.js
+++ b/Flutter.js
@@ -62,3 +62,58 @@ Flutter.prototype.connect = function(successFn) {
 Flutter.prototype.getName = function() {
 	return this.name;
 };
+
+Flutter.prototype.readSensor = function(context, sensorType, port) {
+	if (context.sent) {
+		return (context.requestStatus.finished != true);  // Return true if not finished
+	} else {
+		let request = "flutter/" + HtmlServer.encodeHtml(this.name) + "/in/" + sensorType + "/" + port;
+		context.requestStatus = {};
+		HtmlServer.sendRequest(request, context.requestStatus);
+		context.sent = true;
+		return true;  // Still running
+	}
+};
+
+Flutter.prototype.setServoOrSave = function(shouldSend, context, port, value) {
+	if (context.sent) {
+		return (context.requestStatus.finished != true);  // Return true if not finished
+	} else {
+		if (context.request == null) {
+			// TODO: Validation
+			let requestPrefix = "flutter/" + HtmlServer.encodeHtml(this.name) + "/out/servo/";
+			context.request = requestPrefix + port + "/" + value;
+			context.requestStatus = {};
+		}
+		if (shouldSend) {
+			context.sent = true;
+			HtmlServer.sendRequest(context.request, context.requestStatus);
+			return true;  // Still running
+		} else {
+			context.sent = false;
+			return true;  // Still running
+		}
+	}
+};
+
+
+Flutter.prototype.setTriLEDOrSave = function(shouldSend, context, port, valueR, valueG, valueB) {
+	if (context.sent) {
+		return (context.requestStatus.finished != true);  // Return true if not finished
+	} else {
+		if (context.request == null) {
+			// TODO: Validation
+			let requestPrefix = "flutter/" + HtmlServer.encodeHtml(this.name) + "/out/triled/";
+			context.request = requestPrefix + port + "/" + valueR + "/" + valueG + "/" + valueB;
+			context.requestStatus = {};
+		}
+		if (shouldSend) {
+			context.sent = true;
+			HtmlServer.sendRequest(context.request, context.requestStatus);
+			return true;  // Still running
+		} else {
+			context.sent = false;
+			return true;  // Still running
+		}
+	}
+};

--- a/FlutterManager.js
+++ b/FlutterManager.js
@@ -7,10 +7,38 @@ FlutterManager.ShowDiscoverDialog = function() {
 	DiscoverDialog.show(FlutterManager);
 }
 
+
+FlutterManager.GetDeviceName = function(shorten) {
+	if (shorten) {
+		return "F";
+	} else {
+		return "Flutter";
+	}
+}
+
+FlutterManager.GetDeviceCount = function() {
+	return Object.keys(FlutterManager.connectedDevices).length;
+}
+
+// TODO: Choose either GetDeviceByIndex or GetDeviceByName
+FlutterManager.GetDeviceByIndex = function(index) {
+	// This is a hack because a FIFO list of devices is not kept
+	let devices = Object.keys(FlutterManager.connectedDevices).map(function(key) {
+		return FlutterManager.connectedDevices[key];
+	})
+	return devices[index];
+}
+
+FlutterManager.GetConnectedDevices = function() {
+	let devices = Object.keys(FlutterManager.connectedDevices).map(function(key) {
+		return FlutterManager.connectedDevices[key];
+	})
+	return devices;
+}
+
 /**
  * Static function to discover flutter devices
  *
- * @class      DiscoverDevices
  * @param      {function}  successFn  Callback function called on successful
  *                                    discovery of devices
  * @param      {function}  errorFn    Callback function called on an error in
@@ -21,25 +49,28 @@ FlutterManager.DiscoverDevices = function(successFn, errorFn) {
 }
 
 /**
- * Connects a device and adds it to a list of connected devices.
+ * Connects a device and adds it to a list of connected devices
  *
- * @class      ConnectDevice 
- * @param      {string}  deviceName  The device name
+ * @param      {string}  deviceName  Name of the device to connect
  */
 FlutterManager.ConnectDevice = function(deviceName) {
 	FlutterManager.connectedDevices[deviceName] = new Flutter(deviceName);
 	FlutterManager.connectedDevices[deviceName].connect();
 }
 
+/**
+ * Disconnects a device and removes it from a list of connected devices
+ *
+ * @param      {String}  deviceName  Name of the device to disconnect
+ */
 FlutterManager.DisconnectDevice = function(deviceName) {
 	FlutterManager.connectedDevices[deviceName].disconnect();
 	delete FlutterManager.connectedDevices[deviceName];
 }
 
 /**
- * Gets a device by name.
+ * Gets a device by name
  *
- * @class      GetDeviceByName
  * @param      {string}  deviceName  The device name
  * @return     {Flutter}  The device by name.
  */

--- a/FlutterManager.js
+++ b/FlutterManager.js
@@ -1,6 +1,11 @@
 function FlutterManager() {
 	let mgr = FlutterManager;
 	mgr.connectedDevices = {};
+	mgr.connectionStatus = 2;
+	// 0 - At least 1 disconnected
+	// 1 - Every device is OK
+	// 2 - Nothing connected
+	mgr.UpdateConnectionStatus();
 }
 
 FlutterManager.ShowDiscoverDialog = function() {
@@ -14,6 +19,21 @@ FlutterManager.GetDeviceName = function(shorten) {
 	} else {
 		return "Flutter";
 	}
+}
+
+FlutterManager.GetConnectionStatus = function() {
+	return FlutterManager.connectionStatus;
+}
+
+FlutterManager.UpdateConnectionStatus = function() {
+	HtmlServer.sendRequestWithCallback("flutter/totalStatus", function(result) {
+		FlutterManager.connectionStatus = parseInt(result);
+		if (isNaN(FlutterManager.connectionStatus)) {
+			FlutterManager.connectionStatus = 0;
+		}
+	},function(){
+		FlutterManager.connectionStatus = 0;
+	});
 }
 
 FlutterManager.GetDeviceCount = function() {
@@ -57,6 +77,7 @@ FlutterManager.ConnectDevice = function(deviceName) {
 	FlutterManager.connectedDevices[deviceName] = new Flutter(deviceName);
 	FlutterManager.connectedDevices[deviceName].connect();
 	BlockPalette.getCategory("robots").refreshGroup();
+	FlutterManager.UpdateConnectionStatus();
 }
 
 /**
@@ -68,6 +89,7 @@ FlutterManager.DisconnectDevice = function(deviceName) {
 	FlutterManager.connectedDevices[deviceName].disconnect();
 	delete FlutterManager.connectedDevices[deviceName];
 	BlockPalette.getCategory("robots").refreshGroup();
+	FlutterManager.UpdateConnectionStatus();
 }
 
 /**

--- a/FlutterManager.js
+++ b/FlutterManager.js
@@ -56,6 +56,7 @@ FlutterManager.DiscoverDevices = function(successFn, errorFn) {
 FlutterManager.ConnectDevice = function(deviceName) {
 	FlutterManager.connectedDevices[deviceName] = new Flutter(deviceName);
 	FlutterManager.connectedDevices[deviceName].connect();
+	BlockPalette.getCategory("robots").refreshGroup();
 }
 
 /**
@@ -66,6 +67,7 @@ FlutterManager.ConnectDevice = function(deviceName) {
 FlutterManager.DisconnectDevice = function(deviceName) {
 	FlutterManager.connectedDevices[deviceName].disconnect();
 	delete FlutterManager.connectedDevices[deviceName];
+	BlockPalette.getCategory("robots").refreshGroup();
 }
 
 /**

--- a/GuiElements.js
+++ b/GuiElements.js
@@ -44,7 +44,7 @@ GuiElements.setConstants=function(){
 	BlockList();
 	Colors();
 	//If the constants are only related to the way the UI looks, the method is called setGraphics().
-	HBStatusLight.setConstants();
+	DeviceStatusLight.setConstants();
 	TitleBar.setGraphics();
 	BlockGraphics();
 	Slot.setConstants();

--- a/HummingbirdDragAndDrop.html
+++ b/HummingbirdDragAndDrop.html
@@ -78,7 +78,7 @@
 		<script type="text/javascript" src="BlockParts/Slot/VarDropSlot.js"></script>
 		<script type="text/javascript" src="BlockParts/Slot/ListDropSlot.js"></script>
 		<script type="text/javascript" src="BlockParts/Slot/BroadcastDropSlot.js"></script>
-		<script type="text/javascript" src="BlockParts/Slot/HBDropSlot.js"></script>
+		<script type="text/javascript" src="BlockParts/Slot/DeviceDropSlot.js"></script>
 		
 		<script type="text/javascript" src="BlockParts/Slot/BlockSlot.js"></script>
 		<script type="text/javascript" src="BlockParts/LabelText.js"></script>

--- a/HummingbirdDragAndDrop.html
+++ b/HummingbirdDragAndDrop.html
@@ -84,6 +84,7 @@
 		<script type="text/javascript" src="BlockParts/LabelText.js"></script>
 		<script type="text/javascript" src="BlockParts/BlockIcon.js"></script>
 		<script type="text/javascript" src="BlockDefsAndList/BlockDefs_hummingbird.js"></script>
+		<script type="text/javascript" src="BlockDefsAndList/BlockDefs_flutter.js"></script>
 		<script type="text/javascript" src="BlockDefsAndList/BlockDefs_motion.js"></script>
 		<script type="text/javascript" src="BlockDefsAndList/BlockDefs_looks.js"></script>
 		<script type="text/javascript" src="BlockDefsAndList/BlockDefs_control.js"></script>

--- a/HummingbirdDragAndDrop.html
+++ b/HummingbirdDragAndDrop.html
@@ -28,7 +28,7 @@
 		<script type="text/javascript" src="UIParts/BlockPalette/CategoryBN.js"></script>
 		<script type="text/javascript" src="UIParts/BlockPalette/Category.js"></script>
 		<script type="text/javascript" src="UIParts/Button.js"></script>
-		<script type="text/javascript" src="UIParts/HBStatusLight.js"></script>
+		<script type="text/javascript" src="UIParts/DeviceStatusLight.js"></script>
 		<script type="text/javascript" src="UIParts/InputPad/InputPad.js"></script>
 		<script type="text/javascript" src="UIParts/BubbleOverlay.js"></script>
 		<script type="text/javascript" src="UIParts/ResultBubble.js"></script>

--- a/HummingbirdManager.js
+++ b/HummingbirdManager.js
@@ -10,6 +10,15 @@ function HummingbirdManager(){
 	HM.connectedHBs=[];
 	HM.allowVirtualHBs=false;
 }
+
+HummingbirdManager.GetDeviceName = function(shorten) {
+	if (shorten) {
+		return "HB";
+	} else {
+		return "Hummingbird";
+	}
+}
+
 /* Gets the names of the connected Hummingbirds and saves them to HummingbirdManager.hBNames */
 HummingbirdManager.getHBNames=function(){
 	var HM=HummingbirdManager;
@@ -167,6 +176,9 @@ HummingbirdManager.replaceHBConnection=function(oldHB, newHBName,callbackFn){
 HummingbirdManager.getSelectableHBCount=function(){
 	return HummingbirdManager.selectableHBs;
 };
+HummingbirdManager.GetDeviceCount = function() {
+	return HummingbirdManager.selectableHBs;
+}
 HummingbirdManager.updateSelectableHBs=function(){
 	var HM=HummingbirdManager;
 	var oldCount=HM.selectableHBs;

--- a/HummingbirdManager.js
+++ b/HummingbirdManager.js
@@ -177,7 +177,7 @@ HummingbirdManager.getSelectableHBCount=function(){
 	return HummingbirdManager.selectableHBs;
 };
 HummingbirdManager.GetDeviceCount = function() {
-	return HummingbirdManager.selectableHBs;
+	return HummingbirdManager.connectedHBs.length;
 }
 HummingbirdManager.updateSelectableHBs=function(){
 	var HM=HummingbirdManager;
@@ -191,6 +191,7 @@ HummingbirdManager.updateSelectableHBs=function(){
 	else if(newCount>1&&oldCount<=1){
 		CodeManager.showDeviceDropDowns();
 	}
+	BlockPalette.getCategory("robots").refreshGroup();
 };
 HummingbirdManager.displayDebugInfo=function(){
 	var HM=HummingbirdManager;

--- a/HummingbirdManager.js
+++ b/HummingbirdManager.js
@@ -9,6 +9,11 @@ function HummingbirdManager(){
 	HM.selectableHBs=0;
 	HM.connectedHBs=[];
 	HM.allowVirtualHBs=false;
+	HM.connectionStatus = 2;
+	// 0 - At least 1 disconnected
+	// 1 - Every device is OK
+	// 2 - Nothing connected
+	HM.UpdateConnectionStatus();
 }
 
 HummingbirdManager.GetDeviceName = function(shorten) {
@@ -32,6 +37,21 @@ HummingbirdManager.getHBNames=function(){
 HummingbirdManager.getConnectedHBs=function(){
 	var HM=HummingbirdManager;
 	return HM.connectedHBs;
+};
+
+HummingbirdManager.GetConnectionStatus = function() {
+	return HummingbirdManager.connectionStatus;
+};
+
+HummingbirdManager.UpdateConnectionStatus = function() {
+	HtmlServer.sendRequestWithCallback("hummingbird/totalStatus", function(result) {
+		HummingbirdManager.connectionStatus = parseInt(result);
+		if (isNaN(HummingbirdManager.connectionStatus)) {
+			HummingbirdManager.connectionStatus = 0;
+		}
+	},function(){
+		HummingbirdManager.connectionStatus = 0;
+	});
 };
 HummingbirdManager.outputStartAction=function(block,urlPart,minVal,maxVal){
 	var mem=block.runMem;
@@ -192,6 +212,7 @@ HummingbirdManager.updateSelectableHBs=function(){
 		CodeManager.showDeviceDropDowns();
 	}
 	BlockPalette.getCategory("robots").refreshGroup();
+	HummingbirdManager.UpdateConnectionStatus();
 };
 HummingbirdManager.displayDebugInfo=function(){
 	var HM=HummingbirdManager;

--- a/HummingbirdManager.js
+++ b/HummingbirdManager.js
@@ -186,10 +186,10 @@ HummingbirdManager.updateSelectableHBs=function(){
 	var newCount=Math.max(HM.connectedHBs.length,inUse);
 	HM.selectableHBs=newCount;
 	if(newCount<=1&&oldCount>1){
-		CodeManager.hideHBDropDowns();
+		CodeManager.hideDeviceDropDowns();
 	}
 	else if(newCount>1&&oldCount<=1){
-		CodeManager.showHBDropDowns();
+		CodeManager.showDeviceDropDowns();
 	}
 };
 HummingbirdManager.displayDebugInfo=function(){

--- a/UIParts/BlockPalette/BlockPalette.js
+++ b/UIParts/BlockPalette/BlockPalette.js
@@ -114,13 +114,13 @@ BlockPalette.endScroll=function(){
 		BP.selectedCat.endScroll();
 	}
 };
-BlockPalette.showHBDropDowns=function(){
+BlockPalette.showDeviceDropDowns=function(){
 	for(var i=0;i<BlockPalette.categories.length;i++){
-		BlockPalette.categories[i].showHBDropDowns();
+		BlockPalette.categories[i].showDeviceDropDowns();
 	}
 };
-BlockPalette.hideHBDropDowns=function(){
+BlockPalette.hideDeviceDropDowns=function(){
 	for(var i=0;i<BlockPalette.categories.length;i++){
-		BlockPalette.categories[i].hideHBDropDowns();
+		BlockPalette.categories[i].hideDeviceDropDowns();
 	}
 };

--- a/UIParts/BlockPalette/Category.js
+++ b/UIParts/BlockPalette/Category.js
@@ -188,13 +188,13 @@ Category.prototype.getAbsX=function(){
 Category.prototype.getAbsY=function(){
 	return this.y;
 };
-Category.prototype.showHBDropDowns=function(){
+Category.prototype.showDeviceDropDowns=function(){
 	for(var i=0;i<this.displayStacks.length;i++){
-		this.displayStacks[i].showHBDropDowns();
+		this.displayStacks[i].showDeviceDropDowns();
 	}
 };
-Category.prototype.hideHBDropDowns=function(){
+Category.prototype.hideDeviceDropDowns=function(){
 	for(var i=0;i<this.displayStacks.length;i++){
-		this.displayStacks[i].hideHBDropDowns();
+		this.displayStacks[i].hideDeviceDropDowns();
 	}
 };

--- a/UIParts/BlockPalette/Category.js
+++ b/UIParts/BlockPalette/Category.js
@@ -16,6 +16,7 @@ function Category(buttonX,buttonY,index){
 	this.blocks=new Array();
 	this.displayStacks=new Array();
 	this.buttons=new Array();
+	this.labels=new Array();
 	this.fillGroup();
 	this.scrolling=false;
 	this.scrollXOffset=0;
@@ -41,6 +42,10 @@ Category.prototype.clearGroup=function(){
 		this.buttons[i].remove();
 	}
 	this.buttons=new Array();
+	for(var i=0;i<this.labels.length;i++){
+		this.group.removeChild(this.labels[i]);
+	}
+	this.labels=new Array();
 	this.currentBlockX=BlockPalette.mainHMargin;
 	this.currentBlockY=BlockPalette.mainVMargin;
 	this.lastHadStud=false;
@@ -104,6 +109,7 @@ Category.prototype.addLabel=function(text){
 	var y=this.currentBlockY;
 	var labelE = GuiElements.draw.text(x,y,text,BP.labelFontSize,BP.labelColor,BP.labelFont);
 	this.group.appendChild(labelE);
+	this.labels.push(labelE);
 	var height=GuiElements.measure.textHeight(labelE);
 	GuiElements.move.element(labelE,x,y+height);
 	this.currentBlockY+=height;

--- a/UIParts/ConnectMultipleHBDialog.js
+++ b/UIParts/ConnectMultipleHBDialog.js
@@ -37,7 +37,7 @@ ConnectMultipleHBDialog.setConstants=function(){
 	CMHBD.buttonH=30;
 	CMHBD.bnM=7;
 	CMHBD.smallBnWidth=30;
-	CMHBD.statusToBnM=CMHBD.smallBnWidth+CMHBD.bnM-HBStatusLight.radius*2;
+	CMHBD.statusToBnM=CMHBD.smallBnWidth+CMHBD.bnM-DeviceStatusLight.radius*2;
 	CMHBD.editIconH=15;
 
 	CMHBD.fontSize=16;
@@ -109,9 +109,10 @@ ConnectMultipleHBDialog.prototype.createRow=function(index,y,hummingbird){
 	var CMHBD=ConnectMultipleHBDialog;
 	var x=CMHBD.bnM;
 	var request="hummingbird/"+HtmlServer.encodeHtml(hummingbird.name)+"/status";
-	var statusLight=new HBStatusLight(x,y+CMHBD.buttonH/2,this.group,request);
+	// TODO: Fix status light to work with multiple devices
+	var statusLight=new DeviceStatusLight(x,y+CMHBD.buttonH/2,this.group);
 	this.statusLights.push(statusLight);
-	x+=HBStatusLight.radius*2;
+	x+=DeviceStatusLight.radius*2;
 	var textE=GuiElements.draw.text(0,0,index,CMHBD.fontSize,CMHBD.fontColor,CMHBD.font,CMHBD.fontWeight);
 	var textW=GuiElements.measure.textWidth(textE);
 	var textX=x+CMHBD.statusToBnM/2-textW/2;

--- a/UIParts/DeviceStatusLight.js
+++ b/UIParts/DeviceStatusLight.js
@@ -1,5 +1,5 @@
-function HBStatusLight(x,centerY,parent){
-	var HBSL=HBStatusLight;
+function DeviceStatusLight(x,centerY,parent){
+	var HBSL=DeviceStatusLight;
 	this.cx=x+HBSL.radius;
 	this.cy=centerY;
 	this.parentGroup=parent;
@@ -12,8 +12,8 @@ function HBStatusLight(x,centerY,parent){
 	}
 	thisStatusLight.updateStatus();
 }
-HBStatusLight.setConstants=function(){
-	var HBSL=HBStatusLight;
+DeviceStatusLight.setConstants=function(){
+	var HBSL=DeviceStatusLight;
 	HBSL.greenColor="#0f0";
 	HBSL.redColor="#f00"
 	HBSL.startColor=Colors.black;
@@ -21,11 +21,11 @@ HBStatusLight.setConstants=function(){
 	HBSL.radius=6;
 	HBSL.updateInterval=300;
 };
-HBStatusLight.prototype.generateCircle=function(){
-	var HBSL=HBStatusLight;
+DeviceStatusLight.prototype.generateCircle=function(){
+	var HBSL=DeviceStatusLight;
 	return GuiElements.draw.circle(this.cx,this.cy,HBSL.radius,HBSL.startColor,this.parentGroup);
 };
-HBStatusLight.prototype.updateStatus=function(){
+DeviceStatusLight.prototype.updateStatus=function(){
 	if (HummingbirdManager.GetDeviceCount() > 0) {
 		HummingbirdManager.UpdateConnectionStatus();
 	}
@@ -38,17 +38,17 @@ HBStatusLight.prototype.updateStatus=function(){
 	let overallStatus = Math.min(hbStatus, flutterStatus);  // Lower status means more error
 	switch(overallStatus) {
 		case 0:
-			GuiElements.update.color(this.circleE,HBStatusLight.redColor);
+			GuiElements.update.color(this.circleE,DeviceStatusLight.redColor);
 			break;
 		case 1:
-			GuiElements.update.color(this.circleE,HBStatusLight.greenColor);
+			GuiElements.update.color(this.circleE,DeviceStatusLight.greenColor);
 			break;
 		case 2:
-			GuiElements.update.color(this.circleE,HBStatusLight.offColor);
+			GuiElements.update.color(this.circleE,DeviceStatusLight.offColor);
 			break;
 	}
 };
-HBStatusLight.prototype.remove=function(){
+DeviceStatusLight.prototype.remove=function(){
 	this.circleE.remove();
 	this.updateTimer=window.clearInterval(this.updateTimer);
 };

--- a/UIParts/Flutter/DiscoverDialog.js
+++ b/UIParts/Flutter/DiscoverDialog.js
@@ -30,7 +30,7 @@ DiscoverDialog.selectDevice = function(deviceName){
 DiscoverDialog.setConstants = function(){
 	let Class = DiscoverDialog;
 	Class.instance = null;
-	Class.updateInterval = 1000;
+	Class.updateInterval = 500;
 
 	Class.titleBarColor = Colors.lightGray;
 	Class.titleBarFontC = Colors.white;

--- a/UIParts/HBStatusLight.js
+++ b/UIParts/HBStatusLight.js
@@ -1,11 +1,10 @@
-function HBStatusLight(x,centerY,parent,request){
+function HBStatusLight(x,centerY,parent){
 	var HBSL=HBStatusLight;
 	this.cx=x+HBSL.radius;
 	this.cy=centerY;
 	this.parentGroup=parent;
 	this.circleE=this.generateCircle();
 	var thisStatusLight=this;
-	this.request=request;
 	if(!TouchReceiver.mouse) {
 		this.updateTimer = self.setInterval(function () {
 			thisStatusLight.updateStatus()
@@ -27,21 +26,27 @@ HBStatusLight.prototype.generateCircle=function(){
 	return GuiElements.draw.circle(this.cx,this.cy,HBSL.radius,HBSL.startColor,this.parentGroup);
 };
 HBStatusLight.prototype.updateStatus=function(){
-	var HBSL=HBStatusLight;
-	var thisStatusLight=this;
-	HtmlServer.sendRequestWithCallback(this.request,function(result){
-		if(result=="1"){
-			GuiElements.update.color(thisStatusLight.circleE,HBStatusLight.greenColor);
-		}
-		else if(result=="2"){
-			GuiElements.update.color(thisStatusLight.circleE,HBStatusLight.offColor);
-		}
-		else{
-			GuiElements.update.color(thisStatusLight.circleE,HBStatusLight.redColor);
-		}
-	},function(){
-		GuiElements.update.color(thisStatusLight.circleE,HBStatusLight.redColor);
-	});
+	if (HummingbirdManager.GetDeviceCount() > 0) {
+		HummingbirdManager.UpdateConnectionStatus();
+	}
+	if (FlutterManager.GetDeviceCount() > 0) {
+		FlutterManager.UpdateConnectionStatus();
+	}
+	let hbStatus = HummingbirdManager.GetConnectionStatus();
+	let flutterStatus = FlutterManager.GetConnectionStatus();
+
+	let overallStatus = Math.min(hbStatus, flutterStatus);  // Lower status means more error
+	switch(overallStatus) {
+		case 0:
+			GuiElements.update.color(this.circleE,HBStatusLight.redColor);
+			break;
+		case 1:
+			GuiElements.update.color(this.circleE,HBStatusLight.greenColor);
+			break;
+		case 2:
+			GuiElements.update.color(this.circleE,HBStatusLight.offColor);
+			break;
+	}
 };
 HBStatusLight.prototype.remove=function(){
 	this.circleE.remove();

--- a/UIParts/Menu/HummingbirdMenu.js
+++ b/UIParts/Menu/HummingbirdMenu.js
@@ -13,16 +13,23 @@ HummingbirdMenu.prototype.loadOptions=function(){
 	if(connectedHBs.length>0){
 		var currentHB=connectedHBs[0];
 		this.addOption(currentHB.name,function(){},false);
-		this.addOption("Rename", function(){
+		this.addOption("Rename HB", function(){
 			currentHB.promptRename();
 		});
-		this.addOption("Disconnect", function(){
+		this.addOption("Disconnect HB", function(){
 			currentHB.disconnect();
+		});
+	}
+	if (FlutterManager.GetDeviceCount() > 0) {
+		let firstDevice = FlutterManager.GetConnectedDevices()[0];
+		// TODO: Show all connected devices
+		this.addOption(firstDevice.getName());
+		this.addOption("Disconnect Flutter", function() {
+			FlutterManager.DisconnectDevice(firstDevice.getName());
 		});
 	}
 	this.addOption("Connect HB", HummingbirdManager.showConnectOneDialog);
 	this.addOption("Connect Flutter", FlutterManager.ShowDiscoverDialog);
-	HtmlServer.sendRequestWithCallback("hummingbird/discover");
 };
 HummingbirdMenu.prototype.previewOpen=function(){
 	return (HummingbirdManager.getConnectedHBs().length<=1);

--- a/UIParts/TabManager/Tab.js
+++ b/UIParts/TabManager/Tab.js
@@ -289,11 +289,11 @@ Tab.prototype.checkListUsed=function(list){
 	}
 	return false;
 };
-Tab.prototype.hideHBDropDowns=function(){
-	this.passRecursively("hideHBDropDowns");
+Tab.prototype.hideDeviceDropDowns=function(){
+	this.passRecursively("hideDeviceDropDowns");
 };
-Tab.prototype.showHBDropDowns=function(){
-	this.passRecursively("showHBDropDowns");
+Tab.prototype.showDeviceDropDowns=function(){
+	this.passRecursively("showDeviceDropDowns");
 };
 Tab.prototype.countHBsInUse=function(){
 	var largest=1;

--- a/UIParts/TabManager/TabManager.js
+++ b/UIParts/TabManager/TabManager.js
@@ -216,11 +216,11 @@ TabManager.checkListUsed=function(list){
 	}
 	return false;
 };
-TabManager.hideHBDropDowns=function(){
-	TabManager.passRecursively("hideHBDropDowns");
+TabManager.hideDeviceDropDowns=function(){
+	TabManager.passRecursively("hideDeviceDropDowns");
 };
-TabManager.showHBDropDowns=function(){
-	TabManager.passRecursively("showHBDropDowns");
+TabManager.showDeviceDropDowns=function(){
+	TabManager.passRecursively("showDeviceDropDowns");
 };
 TabManager.countHBsInUse=function(){
 	var largest=1;

--- a/UIParts/TitleBar.js
+++ b/UIParts/TitleBar.js
@@ -31,7 +31,7 @@ TitleBar.createBar=function(){
 	TB.viewBnX=TB.fileBnX+TB.buttonMargin+TB.buttonW;
 
 	TB.hummingbirdBnX=BlockPalette.width-TB.buttonMargin-TB.buttonW;
-	TB.statusX=TB.hummingbirdBnX-TB.buttonMargin-HBStatusLight.radius*2;
+	TB.statusX=TB.hummingbirdBnX-TB.buttonMargin-DeviceStatusLight.radius*2;
 	TB.debugX=TB.flagBnX-TB.longButtonW-2*TB.buttonMargin;
 
 	TB.width=GuiElements.width;
@@ -48,7 +48,7 @@ TitleBar.makeButtons=function(){
 	TB.stopBn.addColorIcon(VectorPaths.stop,TB.bnIconH,TB.stopFill);
 	TB.stopBn.setCallbackFunction(CodeManager.stop,false);
 
-	TB.hBStatusLight=new HBStatusLight(TB.statusX,TB.height/2,TBLayer);
+	TB.deviceStatusLight=new DeviceStatusLight(TB.statusX,TB.height/2,TBLayer);
 	TB.hummingbirdBn=new Button(TB.hummingbirdBnX,TB.buttonMargin,TB.buttonW,TB.buttonH,TBLayer);
 	TB.hummingbirdBn.addImage(ImageLists.hBIcon,TB.bnIconH);
 	TB.hummingbirdMenu=new HummingbirdMenu(TB.hummingbirdBn);

--- a/UIParts/TitleBar.js
+++ b/UIParts/TitleBar.js
@@ -48,7 +48,7 @@ TitleBar.makeButtons=function(){
 	TB.stopBn.addColorIcon(VectorPaths.stop,TB.bnIconH,TB.stopFill);
 	TB.stopBn.setCallbackFunction(CodeManager.stop,false);
 
-	TB.hBStatusLight=new HBStatusLight(TB.statusX,TB.height/2,TBLayer,"hummingbird/totalStatus");
+	TB.hBStatusLight=new HBStatusLight(TB.statusX,TB.height/2,TBLayer);
 	TB.hummingbirdBn=new Button(TB.hummingbirdBnX,TB.buttonMargin,TB.buttonW,TB.buttonH,TBLayer);
 	TB.hummingbirdBn.addImage(ImageLists.hBIcon,TB.bnIconH);
 	TB.hummingbirdMenu=new HummingbirdMenu(TB.hummingbirdBn);


### PR DESCRIPTION
## New
- Flutter and Hummingbird are now merged into a "Robots" tab
  - Blocks for each robot only show up if at least 1 device of the corresponding type is connected
  - Labels for each section of blocks
- Updated status light to show combined status of all robots
- Renamed HBDropSlot -> DeviceDropSlot (+change in constructor to be robot agnostic)
- Renamed HBStatusLight -> DeviceStatusLight (Now the status is only checked when there are connected devices)

## Fixes
- Fixed hack for gradients in Color where there was special casing on gradients for categories that were part of other categories 5627bd4
- Fixed hack for `block.duplicate` to directly calls the callee's constructor and skips creating new fields 		c62cf22
- Fixed removing labels from categories when calling `category.clearGroup` f436ed4
- Sizing issue of Flutter RGB block in Palette 	dd2bf75
- Assorted style cleanup